### PR TITLE
fix(assets): remove a null payload

### DIFF
--- a/assets/aides_logement_schema_fr.json
+++ b/assets/aides_logement_schema_fr.json
@@ -1284,24 +1284,6 @@
           "if": {
             "properties": {
               "kind": {
-                "const": "PasDeGardeAlternee"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "payload": {
-                "title": " ",
-                "type": "null",
-                "default": null
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": {
-              "kind": {
                 "const": "GardeAlterneeCoefficientPriseEnCharge"
               }
             }


### PR DESCRIPTION
It was impossible to add a new `Personne` in the french housing benefits example. It appears that we simply need to remove a null payload to fix it (I don't really get why, but I don't have time to look at it deeper right now).

**However, to be cleaner, the json schema compiler plugin must be updated to not generate null payload.**